### PR TITLE
Modify markdown file excluded in paths filter

### DIFF
--- a/02-mechanics-core/filters/excluded-file.txt
+++ b/02-mechanics-core/filters/excluded-file.txt
@@ -1,0 +1,9 @@
+This change will NOT trigger a workflow run based on these path filters:
+
+```yaml
+paths:
+  # include markdown files
+  - "02-mechanics-core/filters/*.md"
+  # Exclude txt files
+  - "!02-mechanics-core/filters/*.txt"
+```


### PR DESCRIPTION
This will not trigger a workflow run based on: 

```yaml
paths:
  # include markdown files
  - "02-mechanics-core/filters/*.md"
  # Exclude txt files
  - "!02-mechanics-core/filters/*.txt"
```
